### PR TITLE
Bug fix

### DIFF
--- a/cmiles/generator.py
+++ b/cmiles/generator.py
@@ -74,43 +74,48 @@ def to_molecule_id(molecule, canonicalization='openeye'):
     """
     # check input and convert to oe or rdkit mol
     molecule = c.utils.load_molecule(molecule, backend=canonicalization)
+    molecule_copy = deepcopy(molecule)
+    # check for map. If map exists, remove. We only want maps generated with cmiles
+    if c.utils.is_mapped(molecule_copy, backend=canonicalization):
+        c.utils.remove_map(molecule_copy, backend=canonicalization)
+
     smiles = {}
     if canonicalization == 'openeye':
         if not HAS_OPENEYE:
             raise RuntimeError("You do not have OpenEye installed or you are missing the license.")
-        smiles['canonical_smiles'] = to_canonical_smiles_oe(molecule, isomeric=False, explicit_hydrogen=False,
+        smiles['canonical_smiles'] = to_canonical_smiles_oe(molecule_copy, isomeric=False, explicit_hydrogen=False,
                                                              mapped=False)
-        smiles['canonical_isomeric_smiles'] = to_canonical_smiles_oe(molecule, isomeric=True, explicit_hydrogen=False,
+        smiles['canonical_isomeric_smiles'] = to_canonical_smiles_oe(molecule_copy, isomeric=True, explicit_hydrogen=False,
                                                                       mapped=False)
-        smiles['canonical_isomeric_explicit_hydrogen_smiles'] = to_canonical_smiles_oe(molecule, isomeric=True,
+        smiles['canonical_isomeric_explicit_hydrogen_smiles'] = to_canonical_smiles_oe(molecule_copy, isomeric=True,
                                                                                        explicit_hydrogen=True,
                                                                                         mapped=False)
-        smiles['canonical_explicit_hydrogen_smiles'] = to_canonical_smiles_oe(molecule, isomeric=False,
+        smiles['canonical_explicit_hydrogen_smiles'] = to_canonical_smiles_oe(molecule_copy, isomeric=False,
                                                                                explicit_hydrogen=True, mapped=False)
-        smiles['canonical_isomeric_explicit_hydrogen_mapped_smiles'] = to_canonical_smiles_oe(molecule, isomeric=True,
+        smiles['canonical_isomeric_explicit_hydrogen_mapped_smiles'] = to_canonical_smiles_oe(molecule_copy, isomeric=True,
                                                                                                explicit_hydrogen=True,
                                                                                                mapped=True)
         smiles['provenance'] = 'cmiles_' + c.__version__ + '_openeye_' + openeye.__version__
     elif canonicalization == 'rdkit':
         if not HAS_RDKIT:
            raise RuntimeError("You do not have RDKit installed")
-        smiles['canonical_smiles'] = to_canonical_smiles_rd(molecule, isomeric=False, explicit_hydrogen=False,
+        smiles['canonical_smiles'] = to_canonical_smiles_rd(molecule_copy, isomeric=False, explicit_hydrogen=False,
                                                              mapped=False)
-        smiles['canonical_isomeric_smiles'] = to_canonical_smiles_rd(molecule, isomeric=True, explicit_hydrogen=False,
+        smiles['canonical_isomeric_smiles'] = to_canonical_smiles_rd(molecule_copy, isomeric=True, explicit_hydrogen=False,
                                                                       mapped=False)
-        smiles['canonical_isomeric_explicit_hydrogen_smiles'] = to_canonical_smiles_rd(molecule, isomeric=True,
+        smiles['canonical_isomeric_explicit_hydrogen_smiles'] = to_canonical_smiles_rd(molecule_copy, isomeric=True,
                                                                                         explicit_hydrogen=True,
                                                                                         mapped=False)
-        smiles['canonical_explicit_hydrogen_smiles'] = to_canonical_smiles_rd(molecule, isomeric=False,
+        smiles['canonical_explicit_hydrogen_smiles'] = to_canonical_smiles_rd(molecule_copy, isomeric=False,
                                                                                explicit_hydrogen=True, mapped=False)
-        smiles['canonical_isomeric_explicit_hydrogen_mapped_smiles'] = to_canonical_smiles_rd(molecule, isomeric=True,
+        smiles['canonical_isomeric_explicit_hydrogen_mapped_smiles'] = to_canonical_smiles_rd(molecule_copy, isomeric=True,
                                                                                                explicit_hydrogen=True,
                                                                                                mapped=True)
         smiles['provenance'] = 'cmiles_' + c.__version__ + '_rdkit_' + rd.__version__
     else:
         raise TypeError("canonicalization must be either 'openeye' or 'rdkit'")
 
-    smiles['Standard_InChI'], smiles['InChIKey'] = to_inchi_and_key(molecule)
+    smiles['Standard_InChI'], smiles['InChIKey'] = to_inchi_and_key(molecule_copy)
 
     return smiles
 

--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -363,6 +363,7 @@ def test_inchi_key(input, output):
     assert rd_inchi_key == output
 
 @using_openeye
+@using_rdkit
 def test_input_mapped():
     smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
     mol_id = cmiles.to_molecule_id(smiles)
@@ -372,9 +373,6 @@ def test_input_mapped():
     assert cmiles.utils.is_mapped(mol_1) == False
     assert cmiles.utils.is_mapped(mol_2) == True
 
-@using_rdkit
-def test_input_mapped_rd():
-    smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
     mol_id = cmiles.to_molecule_id(smiles, canonicalization='rdkit')
 
     mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'], backend='rdkit')

--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -377,5 +377,5 @@ def test_input_mapped():
 
     mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'], backend='rdkit')
     mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'], backend='rdkit')
-    assert cmiles.utils.is_mapped(mol_1) == False
-    assert cmiles.utils.is_mapped(mol_2) == True
+    assert cmiles.utils.is_mapped(mol_1, backend='rdkit') == False
+    assert cmiles.utils.is_mapped(mol_2, backend='rdkit') == True

--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -362,3 +362,22 @@ def test_inchi_key(input, output):
 
     assert rd_inchi_key == output
 
+@using_openeye
+def test_input_mapped():
+    smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
+    mol_id = cmiles.to_molecule_id(smiles)
+
+    mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'])
+    mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'])
+    assert cmiles.utils.is_mapped(mol_1) == False
+    assert cmiles.utils.is_mapped(mol_2) == True
+
+@using_rdkit
+def test_input_mapped_rd():
+    smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
+    mol_id = cmiles.to_molecule_id(smiles, canonicalization='rdkit')
+
+    mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'])
+    mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'])
+    assert cmiles.utils.is_mapped(mol_1) == False
+    assert cmiles.utils.is_mapped(mol_2) == True

--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -377,7 +377,7 @@ def test_input_mapped_rd():
     smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
     mol_id = cmiles.to_molecule_id(smiles, canonicalization='rdkit')
 
-    mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'])
-    mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'])
+    mol_1 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_smiles'], backend='rdkit')
+    mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'], backend='rdkit')
     assert cmiles.utils.is_mapped(mol_1) == False
     assert cmiles.utils.is_mapped(mol_2) == True

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -5,6 +5,12 @@ import pytest
 from pkg_resources import resource_filename
 import os
 
+rdkit_missing = False
+try:
+    from rdkit import Chem
+except ImportError:
+    rdkit_missing = True
+
 try:
     from openeye import oechem
     openeye_missing = False
@@ -13,7 +19,10 @@ except ImportError:
 
 from .utils import get_fn
 
-@pytest.mark.skipif(openeye_missing, reason="Cannot test without OpenEye" )
+using_rdkit = pytest.mark.skipif(rdkit_missing, reason="Cannot run without RDKit")
+using_openeye = pytest.mark.skipif(openeye_missing, reason="Cannot run without OpenEye")
+
+@using_openeye
 def test_load_molecule():
     """Test load molecules"""
     inputs = ['CCCC', get_fn('butane.pdb'), get_fn('butane.smi'), get_fn('butane.xyz')]
@@ -22,3 +31,23 @@ def test_load_molecule():
         outputs.append(cmiles.utils.load_molecule(i))
     for o in outputs:
         assert oechem.OEMolToSmiles((o)) == 'CCCC'
+
+@using_openeye
+def test_is_mapped_oe():
+    """Test is mapped"""
+    mapped_smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
+    mapped_mol = cmiles.utils.load_molecule(mapped_smiles, backend='openeye')
+    assert cmiles.utils.is_mapped(mapped_mol, backend='openeye') == True
+    cmiles.utils.remove_map(mapped_mol, backend='openeye')
+    assert cmiles.utils.is_mapped(mapped_mol, backend='openeye') == False
+
+
+@using_rdkit
+def test_is_mapped_rd():
+    """Test is mapped"""
+    mapped_smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
+    mapped_mol = cmiles.utils.load_molecule(mapped_smiles, backend='rdkit')
+    assert cmiles.utils.is_mapped(mapped_mol, backend='rdkit') == True
+    cmiles.utils.remove_map(mapped_mol, backend='rdkit')
+    assert cmiles.utils.is_mapped(mapped_mol, backend='rdkit') == False
+

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -116,6 +116,7 @@ def _load_mol_rd(inp_molecule):
             molecule = Chem.MolFromSmiles(inp_molecule)
             if not molecule:
                 raise Warning("Could not parse molecule")
+            return molecule
 
         # Try loading string as file
         try:

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -170,30 +170,16 @@ def _get_extension(filename):
 
 
 def is_mapped(molecule, backend='openeye'):
-
-    if backend == 'openeye':
-        IS_MAPPED = _oe_is_mapped(molecule)
-    elif backend == 'rdkit':
-        IS_MAPPED = _rd_is_mapped(molecule)
-    else:
-        raise TypeError("Only openeye or rdkit are supported backends")
-    print(IS_MAPPED)
-    return IS_MAPPED
-
-
-def _oe_is_mapped(molecule):
     IS_MAPPED = True
     for atom in molecule.GetAtoms():
-        if atom.GetMapIdx() == 0:
-            IS_MAPPED = False
-    return IS_MAPPED
-
-
-def _rd_is_mapped(molecule):
-    IS_MAPPED = True
-    for atom in molecule.GetAtoms():
-        if atom.GetAtomMapNum() == 0:
-            IS_MAPPED = False
+        if backend == 'openeye':
+            if atom.GetMapIdx() == 0:
+                IS_MAPPED = False
+        elif backend == 'rdkit':
+            if atom.GetAtomMapNum() == 0:
+                IS_MAPPED = False
+        else:
+            raise TypeError("Only openeye or rdkit are supported backends")
     return IS_MAPPED
 
 
@@ -209,15 +195,12 @@ def remove_map(molecule, backend='openeye'):
     -------
 
     """
-    print(backend)
-    if backend == 'openeye':
-        for a in molecule.GetAtoms():
+    for a in molecule.GetAtoms():
+        if backend == 'openeye':
             a.SetMapIdx(0)
-        return
-    elif backend == 'rdkit':
-        for a in molecule.GetAtoms():
+        elif backend == 'rdkit':
             a.SetAtomMapNum(0)
-        return
-    else:
-        raise TypeError("Only openeye and rdkit are supported backends")
+        else:
+            raise TypeError("Only openeye and rdkit are supported backends")
+
 

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -168,3 +168,56 @@ def _get_extension(filename):
         return extension2 + extension
     return extension
 
+
+def is_mapped(molecule, backend='openeye'):
+
+    if backend == 'openeye':
+        IS_MAPPED = _oe_is_mapped(molecule)
+    elif backend == 'rdkit':
+        IS_MAPPED = _rd_is_mapped(molecule)
+    else:
+        raise TypeError("Only openeye or rdkit are supported backends")
+    print(IS_MAPPED)
+    return IS_MAPPED
+
+
+def _oe_is_mapped(molecule):
+    IS_MAPPED = True
+    for atom in molecule.GetAtoms():
+        if atom.GetMapIdx() == 0:
+            IS_MAPPED = False
+    return IS_MAPPED
+
+
+def _rd_is_mapped(molecule):
+    IS_MAPPED = True
+    for atom in molecule.GetAtoms():
+        if atom.GetAtomMapNum() == 0:
+            IS_MAPPED = False
+    return IS_MAPPED
+
+
+def remove_map(molecule, backend='openeye'):
+    """
+
+    Parameters
+    ----------
+    molecule
+    backend
+
+    Returns
+    -------
+
+    """
+    print(backend)
+    if backend == 'openeye':
+        for a in molecule.GetAtoms():
+            a.SetMapIdx(0)
+        return
+    elif backend == 'rdkit':
+        for a in molecule.GetAtoms():
+            a.SetAtomMapNum(0)
+        return
+    else:
+        raise TypeError("Only openeye and rdkit are supported backends")
+


### PR DESCRIPTION
## Description
This addressed https://github.com/openforcefield/cmiles/issues/4
This fix removes map from incoming molecules. 
1) We want to make sure the map we generate is canonical so remove existing map
2) When the map is on the molecule, the generated SMILES form `oechem.OEMolToSmiles()` keeps the explicit hydrogen and maps. The lower level function `OECreateSmiString()` also keeps the map if the `OESMILESFLag_ISOMERIC` flag is used
3) For RDKit, the map is generated for all flavors of SMILES once it exists in the molecule since there is no flag to ignore map indices for `MolToSmiles()`