### PR TITLE
Add chemical formula and unique identifier

### DIFF
--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -400,3 +400,15 @@ def test_chemical_formula_rd():
     assert formula == 'C4H10'
 
 
+@pytest.mark.parametrize('state1, state2',
+                          [('CC(=O)O','CC(=O)[O-]'), # protonation states
+                           ('CN4CCN(c2nc1cc(Cl)ccc1[nH]c3ccccc23)CC4', 'CN4CCN(c2[nH]c1cc(Cl)ccc1nc3ccccc23)CC4'), # 1,5 tautomerism
+                           ('CC=CC(=O)C', 'CC(=CC=C)O')]) # keto-enol
+
+@using_openeye
+def test_unique_protomer(state1, state2):
+    """Test unique protomer"""
+    mol_1 = cmiles.utils.load_molecule(state1)
+    mol_2 = cmiles.utils.load_molecule(state2)
+    assert cmiles.get_unique_protomer(mol_1) == cmiles.get_unique_protomer(mol_2)
+

--- a/cmiles/tests/test_cmiles.py
+++ b/cmiles/tests/test_cmiles.py
@@ -379,3 +379,24 @@ def test_input_mapped():
     mol_2 = cmiles.utils.load_molecule(mol_id['canonical_isomeric_explicit_hydrogen_mapped_smiles'], backend='rdkit')
     assert cmiles.utils.is_mapped(mol_1, backend='rdkit') == False
     assert cmiles.utils.is_mapped(mol_2, backend='rdkit') == True
+
+
+@using_openeye
+def test_chemical_formula_oe():
+    from openeye import oechem
+    smiles = 'CCCC'
+    molecule = cmiles.utils.load_molecule(smiles, backend='openeye')
+    oechem.OEAddExplicitHydrogens(molecule)
+    formula = cmiles.generator.molecular_formula(molecule, backend='openeye')
+    assert formula == 'C4H10'
+
+@using_rdkit
+def test_chemical_formula_rd():
+    from rdkit import Chem
+    smiles = 'CCCC'
+    molecule = cmiles.utils.load_molecule(smiles, backend='rdkit')
+    molecule = Chem.AddHs(molecule)
+    formula = cmiles.generator.molecular_formula(molecule, backend='rdkit')
+    assert formula == 'C4H10'
+
+


### PR DESCRIPTION
## Description
This PR adds 2 'universal' identifiers. 
1) The chemical formula
2) OpenEye's unique protomer
OpenEye's unique identifiers capture protonation states and tautomers but does not normalize for stereoisomers. 

@jchodera, Currently there is no equivalent function in RDKit as `quacpac.OEGetUniqueProtomer()` so the OpenEye's license is needed for this. However, we can probably use the first 2 layers of the InChI (chemical formula and connectivity) for an approximate comparison of tautomers, protonations states and stereoisomers. If we also use the hydrogen layer of the main layer we can miss some tautomer classes that InChI doesn't normalize (keto-enol, 1,5-tautomerism). 

## Status
- [ ] Ready to go