### PR TITLE
[WIP] Fix some problems with atom map indices

### DIFF
--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -130,6 +130,9 @@ def mol_to_smiles(molecule, isomeric=True, explicit_hydrogen=True, mapped=True):
 
     molecule = oechem.OEMol(molecule)
 
+    if has_atom_map(molecule):
+        raise ValueError("Why oh why does the molecule still have map indices if it was already removed???")
+
     if explicit_hydrogen:
         if not has_explicit_hydrogen(molecule):
             oechem.OEAddExplicitHydrogens(molecule)
@@ -351,11 +354,41 @@ def has_stereo_defined(molecule):
 
 
 def has_atom_map(molecule):
-    IS_MAPPED = True
+    """
+    Checks if any atom has map indices. Will return True if even only one atom has a map index
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    IS_MAPPED = False
+    for atom in molecule.GetAtoms():
+            if atom.GetMapIdx() != 0:
+                IS_MAPPED = True
+                return IS_MAPPED
+    return IS_MAPPED
+
+
+def is_missing_atom_map(molecule):
+    """
+    Checks if any atom in molecule is missing a map index. If even only one atom is missing a map index will return True
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    MISSING_ATOM_MAP = False
     for atom in molecule.GetAtoms():
             if atom.GetMapIdx() == 0:
-                IS_MAPPED = False
-    return IS_MAPPED
+                MISSING_ATOM_MAP = True
+                return MISSING_ATOM_MAP
+    return MISSING_ATOM_MAP
 
 
 def remove_atom_map(molecule):

--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -246,7 +246,16 @@ def get_atom_map(molecule, mapped_smiles):
     # sanity check
     mol = oechem.OEGraphMol()
     oechem.OESubsetMol(mol, match, True)
-    print("Match SMILES: {}".format(oechem.OEMolToSmiles(mol)))
+    remove_atom_map(mol)
+    matched_smiles = oechem.OEMolToSmiles(mol)
+    molcopy = oechem.OEMol(molecule)
+    if has_atom_map(molcopy):
+        remove_atom_map(molcopy)
+    smiles = oechem.OEMolToSmiles(molcopy)
+    remove_atom_map(mapped_mol)
+    pattern_smiles = oechem.OEMolToSmiles(mapped_mol)
+    if not matched_smiles == smiles == pattern_smiles:
+        raise RuntimeError("Matched molecule, input molecule and mapped SMILES are not the same ")
     return atom_map
 
 

--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -1,6 +1,7 @@
 """
 
 """
+import openeye as toolkit
 from openeye import oechem
 import copy
 import warnings

--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -46,10 +46,13 @@ def mol_from_json(symbols, connectivity, geometry, permute_xyz=False):
     molecule.SetCoords(oechem.OEFloatArray(geometry))
     molecule.SetDimension(3)
 
-    if not permute_xyz:
-        # Add tag that the geometry is from JSON and shouldn't be changed.
-        geom_tag = oechem.OEGetTag("json_geometry")
+    geom_tag = oechem.OEGetTag("json_geometry")
+    if permute_xyz:
+        # Add tag that the geometry is from JSON but can be changed.
+        molecule.SetData(geom_tag, False)
+    else:
         molecule.SetData(geom_tag, True)
+
     oechem.OEDetermineConnectivity(molecule)
     oechem.OEFindRingAtomsAndBonds(molecule)
     oechem.OEPerceiveBondOrders(molecule)
@@ -179,7 +182,7 @@ def mol_to_smiles(molecule, isomeric=True, explicit_hydrogen=True, mapped=True):
     return oechem.OEMolToSmiles(molecule)
 
 
-def get_connectivity_table(molecule, inverse_map):
+def get_connectivity_table(molecule):
     """
 
     Parameters
@@ -191,15 +194,20 @@ def get_connectivity_table(molecule, inverse_map):
     -------
 
     """
-    connectivity_table = [[inverse_map[bond.GetBgnIdx()]-1, inverse_map[bond.GetEndIdx()]-1, bond.GetOrder()] for bond
+    # Check that molecule is in canonical order
+    if not is_molecule_canonical_order(molecule):
+        raise ValueError("Molecule atoms are not in canonical order")
+    connectivity_table = [[bond.GetBgnIdx(), bond.GetEndIdx(), bond.GetOrder()] for bond
                           in molecule.GetBonds()]
 
     return connectivity_table
 
 
-def get_atom_map(molecule, mapped_smiles, strict=True):
+def get_atom_map(molecule, mapped_smiles):
     """
     Map tag in mapped SMILES to atom idx
+    This uses a substructure search. For a symmetrical molecule, there are as many matches as symmetries and atom maps can flip.
+    It should only be used if the mapped SMILES was not generated with openeye.
 
     Parameters
     ----------
@@ -219,65 +227,63 @@ def get_atom_map(molecule, mapped_smiles, strict=True):
     if not has_explicit_hydrogen(molecule):
         raise ValueError("Molecule must have explicit hydrogen")
 
-    # Check that map SMILES has map indices on all atoms and that it's in canonical order.
-    mapped_mol = oechem.OEMol()
-    oechem.OESmilesToMol(mapped_mol, mapped_smiles)
-    # Check for explicit hydrogen
-    if not has_explicit_hydrogen(mapped_mol):
-        raise ValueError("Mapped SMILES must include explicit hydrogen")
-
-    # Check that all atoms have map indices
-    if is_missing_atom_map(mapped_mol):
-        # mapped SMILES must have map index on every atom
-        raise ValueError("Mapped SMILES must have map indices for all atoms and hydrogen")
-
-    # check canonical order of atom map
-    if not is_map_canonical(mapped_mol):
-        if strict:
-            raise ValueError("Map indices on mapped SMILES are not in openeye canonical order. If you set strict to False, "
-                             "you can get an atom map but only do this if you understand what you are doing.")
-        # map in mapped SMILES is not canonical - it might come from RDKit
-        can_mapped_smiles = False
-    else:
-        can_mapped_smiles = True
-
-    if can_mapped_smiles:
-        # Mapped SMILES is canonical. Get atom map from canonical ordered molecule
-        molcopy = oechem.OEMol(molecule)
-        # store atom indices in molecule data
-        for atom in molcopy.GetAtoms():
-            atom.SetData('atom_idx', atom.GetIdx())
-        canonical_order_atoms(molcopy)
-        atom_map = {}
-        for atom in molcopy.GetAtoms():
-            atom_map[atom.GetIdx()+1] = atom.GetData('atom_idx')
-    elif not can_mapped_smiles and not strict:
-        warnings.warn("Using substructure search to get atom map. If your molecule is symmetric, more than one atom mapping"
-                      " is possible and the order of the geometry can flip.")
+    # # Check that map SMILES has map indices on all atoms and that it's in canonical order.
+    # mapped_mol = oechem.OEMol()
+    # oechem.OESmilesToMol(mapped_mol, mapped_smiles)
+    # # Check for explicit hydrogen
+    # if not has_explicit_hydrogen(mapped_mol):
+    #     raise ValueError("Mapped SMILES must include explicit hydrogen")
+    #
+    # # Check that all atoms have map indices
+    # if is_missing_atom_map(mapped_mol):
+    #     # mapped SMILES must have map index on every atom
+    #     raise ValueError("Mapped SMILES must have map indices for all atoms and hydrogen")
+    #
+    # # check canonical order of atom map
+    # if not is_map_canonical(mapped_mol):
+    #     if strict:
+    #         raise ValueError("Map indices on mapped SMILES are not in openeye canonical order. If you set strict to False, "
+    #                          "you can get an atom map but only do this if you understand what you are doing.")
+    #     # map in mapped SMILES is not canonical - it might come from RDKit
+    #     can_mapped_smiles = False
+    # else:
+    #     can_mapped_smiles = True
+    #
+    # if can_mapped_smiles:
+    #     # Mapped SMILES is canonical. Get atom map from canonical ordered molecule
+    #     molcopy = oechem.OEMol(molecule)
+    #     # store atom indices in molecule data
+    #     for atom in molcopy.GetAtoms():
+    #         atom.SetData('atom_idx', atom.GetIdx())
+    #     canonical_order_atoms(molcopy)
+    #     atom_map = {}
+    #     for atom in molcopy.GetAtoms():
+    #         atom_map[atom.GetIdx()+1] = atom.GetData('atom_idx')
+    # elif not can_mapped_smiles and not strict:
+    #     warnings.warn("Using substructure search to get atom map. If your molecule is symmetric, more than one atom mapping"
+    #                   " is possible and the order of the geometry can flip.")
         # Use substructure search
-        ss = oechem.OESubSearch(mapped_smiles)
-        oechem.OEPrepareSearch(molecule, ss)
-        ss.SetMaxMatches(1)
+    ss = oechem.OESubSearch(mapped_smiles)
+    oechem.OEPrepareSearch(molecule, ss)
+    ss.SetMaxMatches(1)
 
-        atom_map = {}
-        matches = [m for m in ss.Match(molecule)]
-        if not matches:
-            raise RuntimeError("MCSS failed for {}, smiles: {}".format(oechem.OEMolToSmiles(molecule), mapped_smiles))
-        for match in matches:
-            for ma in match.GetAtoms():
-                atom_map[ma.pattern.GetMapIdx()] = ma.target.GetIdx()
+    atom_map = {}
+    matches = [m for m in ss.Match(molecule)]
+    if not matches:
+        raise RuntimeError("MCSS failed for {}, smiles: {}".format(oechem.OEMolToSmiles(molecule), mapped_smiles))
+    for match in matches:
+        for ma in match.GetAtoms():
+            atom_map[ma.pattern.GetMapIdx()] = ma.target.GetIdx()
 
-        # sanity check
-        mol = oechem.OEGraphMol()
-        oechem.OESubsetMol(mol, match, True)
-        print("Match SMILES: {}".format(oechem.OEMolToSmiles(mol)))
-    else:
-        raise RuntimeError("Mapped indices on mapped SMILES are not canonical.")
+    # sanity check
+    mol = oechem.OEGraphMol()
+    oechem.OESubsetMol(mol, match, True)
+    print("Match SMILES: {}".format(oechem.OEMolToSmiles(mol)))
 
     return atom_map
 
 
-def get_map_ordered_geometry(molecule, atom_map):
+def get_map_ordered_geometry(molecule, mapped_smiles):
     """
 
     Parameters
@@ -301,11 +307,31 @@ def get_map_ordered_geometry(molecule, atom_map):
         if molecule.GetMaxConfIdx() != 1:
             raise Warning("The molecule must have at least and at most 1 conformation")
 
+    # Check for JSON geometry
+    try:
+        json_geometry = molecule.GetData('json_geometry')
+    except ValueError:
+        json_geometry = None
+
+    # Check that map SMILES and order in geometry all match up
+    if not is_mapped_smiles_canonical(mapped_smiles):
+        raise ValueError("Map indices on SMILES are not canonical")
+    if not is_goemetry_canonical_order(molecule):
+        if json_geometry is None:
+            raise ValueError("Geometry was not generated with omega canonical order set to True")
+    if not is_molecule_canonical_order(molecule):
+        if json_geometry is None:
+            raise ValueError("molecule atoms are not in canonical order")
+        elif json_geometry:
+            pass
+        elif json_geometry is False:
+             canonical_order_atoms(molecule)
+
     symbols = []
     geometry = []
-    for mapping in range(1, molecule.NumAtoms()+1):
-        idx = atom_map[mapping]
-        atom = molecule.GetAtom(oechem.OEHasAtomIdx(idx))
+    #for mapping in range(1, molecule.NumAtoms()+1):
+    for atom in molecule.GetAtoms():
+        #atom = molecule.GetAtom(oechem.OEHasAtomIdx(idx))
         syb = oechem.OEGetAtomicSymbol(atom.GetAtomicNum())
         symbols.append(syb)
         for i in range(3):
@@ -469,25 +495,103 @@ def restore_atom_map(molecule):
             atom.SetMapIdx(atom.GetData('MapIdx'))
 
 
-def is_map_canonical(molecule):
+# def is_map_canonical(molecule):
+#     """
+#     Check if map indices on molecule is in canonical order.
+#     Reorder atoms to be in canonical order and compare the atom order to the map indices.
+#
+#     Parameters
+#     ----------
+#     molecule: OEMol created from the mapped SMILES
+#
+#     Returns
+#     -------
+#     True if canonical ordered atoms match map indices. False otherwise.
+#
+#     """
+#     molcopy = oechem.OEMol(molecule)
+#     # reorder molcopy
+#     canonical_order_atoms(molcopy, in_place=True)
+#     # Now check that map indices are +1 on atom indices
+#     for a in molcopy.GetAtoms():
+#         if a.GetMapIdx() != a.GetIdx() + 1:
+#             return False
+#     return True
+
+
+def is_mapped_smiles_canonical(mapped_smiles):
     """
-    Check if map indices on molecule is in canonical order.
-    Reorder atoms to be in canonical order and compare the atom order to the map indices.
 
     Parameters
     ----------
-    molecule: OEMol created from the mapped SMILES
+    mapped_smiles
 
     Returns
     -------
-    True if canonical ordered atoms match map indices. False otherwise.
+
+    """
+    mol = oechem.OEMol()
+    oechem.OESmilesToMol(mol, mapped_smiles)
+    # romove map
+    remove_atom_map(mol)
+    # Generate canonical mapped SMILES
+    if not mol_to_smiles(mol, mapped=True, explicit_hydrogen=True, isomeric=True) == mapped_smiles:
+        # This mapped SMILES was not generated by CMILES with openeye.
+        return False
+    return True
+    #
+
+
+def is_goemetry_canonical_order(molecule):
+    """
+
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    # Check that molecule has geometry
+    if not molecule.GetDimension() == 3:
+        raise ValueError("Molecule must have 3D coordinates")
+    molecule_copy = oechem.OEMol(molecule)
+    canonical_order_atoms(molecule_copy)
+    if not molecule.GetCoords() == molecule_copy.GetCoords():
+        # geometry was not generated with canonical order set to True
+        warnings.warn("Geometry was not generated with canonical order set to True")
+        return False
+    return True
+
+
+def is_molecule_canonical_order(molecule):
+    """
+
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
 
     """
     molcopy = oechem.OEMol(molecule)
-    # reorder molcopy
-    canonical_order_atoms(molcopy, in_place=True)
-    # Now check that map indices are +1 on atom indices
-    for a in molcopy.GetAtoms():
-        if a.GetMapIdx() != a.GetIdx() + 1:
-            return False
+    if has_atom_map(molcopy):
+        remove_atom_map(molcopy)
+    # Check for JSON geometry
+    try:
+        json_geometry = molcopy.GetData('json_geometry')
+        if json_geometry:
+            molcopy.SetData('json_geometry', False)
+    except ValueError:
+        pass
+    canonical_mapped_smiles = mol_to_smiles(molcopy, isomeric=True, explicit_hydrogen=True, mapped=True)
+
+    # Add map indices to molcopy
+    for atom in molcopy.GetAtoms():
+        atom.SetMapIdx(atom.GetIdx() + 1)
+    mapped_smiles = oechem.OEMolToSmiles(molcopy)
+    if not canonical_mapped_smiles == mapped_smiles:
+        return False
     return True

--- a/cmiles/_cmiles_rd.py
+++ b/cmiles/_cmiles_rd.py
@@ -304,12 +304,42 @@ def has_stereo_defined(molecule):
 
 
 def has_atom_map(molecule):
-    IS_MAPPED = True
+    """
+    Checks if any atom has map indices. Will return True if even only one atom has a map index
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    IS_MAPPED = False
     for atom in molecule.GetAtoms():
-        if atom.GetAtomMapNum() == 0:
-            IS_MAPPED = False
+            if atom.GetAtomMapNum() != 0:
+                IS_MAPPED = True
+                return IS_MAPPED
     return IS_MAPPED
 
+
+def is_missing_atom_map(molecule):
+    """
+    Checks if any atom in molecule is missing a map index. If even only one atom is missing a map index will return True
+
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    MISSING_ATOM_MAP = False
+    for atom in molecule.GetAtoms():
+            if atom.GetAtomMapNum() == 0:
+                MISSING_ATOM_MAP = True
+                return MISSING_ATOM_MAP
+    return MISSING_ATOM_MAP
 
 def remove_atom_map(molecule):
     for a in molecule.GetAtoms():

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -211,6 +211,8 @@ def test_get_atom_map(toolkit, toolkit_name):
     if toolkit_name == 'openeye':
         from openeye import oechem
         oechem.OEAddExplicitHydrogens(mol)
+        # canonical order atoms
+        _cmiles_oe.canonical_order_atoms(mol, in_place=True)
         for a in mol.GetAtoms():
             a.SetMapIdx(a.GetIdx()+1)
         mapped_smiles = oechem.OEMolToSmiles(mol)
@@ -222,7 +224,7 @@ def test_get_atom_map(toolkit, toolkit_name):
             a.SetAtomMapNum(a.GetIdx()+1)
         mapped_smiles = Chem.MolToSmiles(mol)
 
-    atom_map = utils.get_atom_map(mol, mapped_smiles)
+    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles)
 
     for m in atom_map:
         assert m == (atom_map[m] + 1)
@@ -240,7 +242,7 @@ def test_get_atom_map(toolkit, toolkit_name):
 def test_connectivity(mapped_smiles, expected_table, toolkit):
     """Test connectivity table"""
     molecule = utils.load_molecule(mapped_smiles, toolkit)
-    atom_map = utils.get_atom_map(molecule, mapped_smiles)
+    atom_map = utils.get_atom_map(molecule, mapped_smiles=mapped_smiles)
     connectivity_table = utils.get_connectivity_table(molecule, atom_map)
 
     for bond in connectivity_table:
@@ -269,7 +271,7 @@ def test_map_order_geometry(permute, toolkit, toolkit_name):
     }
     mol = utils.load_molecule(hooh, toolkit=toolkit_name, permute_xyz=permute)
     mapped_smiles = utils.mol_to_smiles(mol, isomeric=True, explicit_hydrogen=True, mapped=True)
-    atom_map = utils.get_atom_map(mol, mapped_smiles)
+    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles, strict=permute)
     symbols, geometry = toolkit.get_map_ordered_geometry(mol, atom_map)
 
     json_geom = np.asarray(hooh['geometry']).reshape(int(len(geometry)/3), 3)
@@ -309,7 +311,7 @@ def test_permute_json(toolkit):
         'molecular_multiplicity': 1
     }
     mol = utils.mol_from_json(hooh, toolkit=toolkit)
-    atom_map = utils.get_atom_map(mol, '[H:3][O:1][O:2][H:4]')
+    atom_map = utils.get_atom_map(mol, mapped_smiles='[H:3][O:1][O:2][H:4]')
     permuted_hooh = utils.permute_qcschema(hooh, molecule_ids, toolkit=toolkit)
 
     json_geom = np.asarray(hooh['geometry']).reshape(int(len(hooh['geometry'])/3), 3)
@@ -328,6 +330,21 @@ def test_get_atom_map_mapped_smiles(toolkit):
     mol_1 = utils.load_molecule(smiles_1, toolkit=toolkit)
     mol_2 = utils.load_molecule(smiles_2, toolkit=toolkit)
 
-    assert utils.get_atom_map(mol_2, smiles_2)
+    assert utils.get_atom_map(mol_2, mapped_smiles=smiles_2)
     with pytest.raises(ValueError):
-        utils.get_atom_map(mol_1, smiles_1)
+        utils.get_atom_map(mol_1, mapped_smiles=smiles_1)
+
+
+@pytest.mark.parametrize('toolkit', toolkits_name)
+def test_remove_restore_atom_map(toolkit):
+    mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
+    mapped_mol = utils.load_molecule(mapped_smiles, toolkit=toolkit)
+
+    utils.remove_atom_map(mapped_mol)
+    assert utils.has_atom_map(mapped_mol) == False
+    assert utils.is_missing_atom_map(mapped_mol) == True
+
+    utils.restore_atom_map(mapped_mol)
+    assert utils.has_atom_map(mapped_mol) == True
+    assert utils.is_missing_atom_map(mapped_mol) == False
+

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -37,7 +37,6 @@ def test_load_molecule(toolkit):
 @pytest.mark.parametrize('input, output', [('[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]', True),
                                            ('[H:3][C:1]([H])([H:5])[C]([H])([H:7])[H:8]', True),
                                            ('CCCC', False)])
-
 def test_is_mapped(toolkit, input, output):
     """Test is mapped"""
     mapped_mol = utils.load_molecule(input, toolkit=toolkit)
@@ -54,6 +53,7 @@ def test_is_missing_map(toolkit, input, output):
     #ToDo - Known problem that RDKit does not add explicit H to molecules even with explicit H SMILES so if map of H is missing it will not pick it up
     mol = utils.load_molecule(input, toolkit=toolkit)
     assert utils.is_missing_atom_map(mol) == output
+
 
 @pytest.mark.parametrize('toolkit_str', toolkits_name)
 def test_mol_from_json(toolkit_str):
@@ -112,6 +112,7 @@ def test_has_stereochemistry(input1, input2, toolkit_name):
     with pytest.warns(UserWarning):
         utils.has_stereo_defined(mol)
 
+
 @using_openeye
 def test_canonical_order_oe():
     """Test canonical atom order"""
@@ -159,26 +160,28 @@ def test_canonical_order_rd():
 
 @pytest.mark.parametrize('toolkit_name', toolkits_name)
 @pytest.mark.parametrize('input, output', [('COC(C)c1c(Cl)ccc(F)c1Cl', False),
-                                          ('C[C@@H](c1c(ccc(c1Cl)F)Cl)OC', False),
-                                          ('O=O', True),
-                                          ('[CH3:1][CH2:3][CH2:4][CH3:2]', False)])
+                                           ('C[C@@H](c1c(ccc(c1Cl)F)Cl)OC', False),
+                                           ('O=O', True),
+                                           ('[CH3:1][CH2:3][CH2:4][CH3:2]', False)])
 def test_explicit_h(input, output, toolkit_name):
     """Test input SMILES for explicit H"""
     mol = utils.load_molecule(input, toolkit=toolkit_name)
     assert utils.has_explicit_hydrogen(mol) == output
 
+
 @using_rdkit
 @pytest.mark.parametrize('input, output', [('[H]c1c(c(c(c(c1F)Cl)[C@]([H])(C([H])([H])[H])OC([H])([H])[H])Cl)[H]', False),
-                                          ('[C:1]([O:2][H:6])([H:3])([H:4])[H:5]', False)])
+                                           ('[C:1]([O:2][H:6])([H:3])([H:4])[H:5]', False)])
 def test_explicit_h_rd(input, output):
     """Test input SMILES for explicit H"""
 
     mol = utils.load_molecule(input, toolkit='rdkit')
     assert utils.has_explicit_hydrogen(mol) == output
 
+
 @using_openeye
 @pytest.mark.parametrize('input, output', [('[H]c1c(c(c(c(c1F)Cl)[C@]([H])(C([H])([H])[H])OC([H])([H])[H])Cl)[H]', True),
-                                          ('[C:1]([O:2][H:6])([H:3])([H:4])[H:5]', True)])
+                                           ('[C:1]([O:2][H:6])([H:3])([H:4])[H:5]', True)])
 def test_explicit_h_oe(input, output):
     """Test input SMILES for explicit H"""
 
@@ -226,7 +229,7 @@ def test_get_atom_map(toolkit, toolkit_name):
 
 
 @pytest.mark.parametrize('mapped_smiles, expected_table', [('[H:5][C:1]([H:6])([H:7])[C:3]([H:11])([H:12])[C:4]([H:13])([H:14])[C:2]([H:8])([H:9])[H:10]',
-                                                          np.array([[0, 2, 1], [1, 3, 1],[2, 3, 1],[0, 4, 1],[0, 5, 1],
+                                                           np.array([[0, 2, 1], [1, 3, 1],[2, 3, 1],[0, 4, 1],[0, 5, 1],
                                                                     [0, 6, 1],[1, 7, 1],[1, 8, 1],[1, 9, 1],[2, 10, 1],
                                                                     [2, 11, 1],[3, 12, 1],[3, 13, 1]])),
                                                            ('[H:7][c:1]1[c:2]([c:4]([o:5][c:3]1[H:9])[O:6][H:10])[H:8]',
@@ -316,6 +319,7 @@ def test_permute_json(toolkit):
     for m in atom_map:
         for i in range(3):
             assert json_geom[atom_map[m]][i] == pytest.approx(permuted_geom[m-1][i], 0.0000001)
+
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
 def test_get_atom_map_mapped_smiles(toolkit):

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -397,6 +397,11 @@ def test_remove_restore_atom_map(toolkit):
     assert utils.has_atom_map(mapped_mol) == True
     assert utils.is_missing_atom_map(mapped_mol) == False
 
+    smiles = 'OCCO'
+    mol = utils.load_molecule(smiles, toolkit=toolkit)
+    with pytest.warns(UserWarning):
+        utils.restore_atom_map(mol)
+
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
 @pytest.mark.parametrize('smiles, canonicalization', [('[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]', 'openeye'),

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -224,7 +224,7 @@ def test_get_atom_map(toolkit, toolkit_name):
             a.SetAtomMapNum(a.GetIdx()+1)
         mapped_smiles = Chem.MolToSmiles(mol)
 
-    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles)
+    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles, strict=False)
 
     for m in atom_map:
         assert m == (atom_map[m] + 1)
@@ -234,23 +234,40 @@ def test_get_atom_map(toolkit, toolkit_name):
                                     '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]',
                                    '[H][O][C]([H])([H])[C]([H])([H])[O][H]',
                                     '[O:1]([C:3]([C:4]([O:2][H:6])([H:9])[H:10])([H:7])[H:8])[H:5]'])
-def test_geometry_order(smiles):
-    """Test that geometry is ordered the same way every time no matter the SMILES used to create the molecule"""
+def test_atom_map(smiles):
+    """Test that atom map orders geometry the same way every time no matter the SMILES used to create the molecule"""
     import cmiles
-    from .utils import generate_conformers
     mapped_smiles = '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]'
     mol_id_oe = cmiles.to_molecule_id(mapped_smiles, canonicalization='openeye')
     oemol = utils.load_molecule(mapped_smiles, toolkit='openeye')
-    # Generate canonical geometry
-    conf = generate_conformers(oemol, canonical_order=True, max_confs=1)
-    mapped_symbols, mapped_geometry = _cmiles_oe.get_map_ordered_geometry(conf, mapped_smiles)
+    mapped_symbols = ['C', 'C', 'O', 'O', 'H', 'H', 'H', 'H', 'H', 'H']
+    mapped_geometry = [-1.6887193912042044, 0.8515190939276903, 0.8344587822904272, -4.05544806361675, -0.3658269566455062,
+                       -0.22848169646448416, -1.6111611950422127, 0.4463128276938808, 3.490617694146934, -3.97756355964586,
+                       -3.0080934853087373, 0.25948499322223956, -1.6821252026076652, 2.891135395246369, 0.4936556190978574,
+                       0.0, 0.0, 0.0, -4.180315034973438, -0.09210893239246959, -2.2748227320305525, -5.740516456782416,
+                       0.4115539217904015, 0.6823267491485907, -0.07872657410528058, 1.2476492272884379, 4.101615944163073,
+                       -5.514569080545831, -3.7195945404657222, -0.4441653010509862]
 
-    # Generate new molecule from other SMILES
     mol = cmiles.utils.load_molecule(smiles, toolkit='openeye')
     if not utils.has_explicit_hydrogen(mol):
         mol = utils.add_explicit_hydrogen(mol)
-    conf_2 = generate_conformers(mol, canonical_order=True, max_confs=1)
-    symbols, geometry = _cmiles_oe.get_map_ordered_geometry(conf_2, mapped_smiles)
+    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles)
+    # use the atom map to add coordinates to molecule. First reorder mapped geometry to order in molecule
+    mapped_coords = np.array(mapped_geometry, dtype=float).reshape(int(len(mapped_geometry)/3), 3)
+    coords = np.zeros((mapped_coords.shape))
+    for m in atom_map:
+        coords[atom_map[m]] = mapped_coords[m-1]
+    # flatten
+    coords = coords.flatten()
+    # convert to Angstroms
+    coords = coords*utils.BOHR_2_ANGSTROM
+    # set coordinates in oemol
+    mol.SetCoords(coords)
+    mol.SetDimension(3)
+
+    # Get new atom map
+    atom_map = utils.get_atom_map(mol, mapped_smiles)
+    symbols, geometry = _cmiles_oe.get_map_ordered_geometry(mol, atom_map)
     assert geometry == mapped_geometry
     assert symbols == mapped_symbols
 
@@ -269,11 +286,8 @@ def test_connectivity(mapped_smiles, expected_table, toolkit):
     molecule = utils.load_molecule(mapped_smiles, toolkit)
     if not utils.has_explicit_hydrogen(molecule):
         molecule = utils.add_explicit_hydrogen(molecule)
-    if toolkit == 'rdkit':
-        atom_map = utils.get_atom_map(molecule, mapped_smiles=mapped_smiles, strict=False)
-    if toolkit == 'openeye':
-        _cmiles_oe.canonical_order_atoms(molecule)
-    connectivity_table = utils.get_connectivity_table(molecule)
+    atom_map = utils.get_atom_map(molecule, mapped_smiles=mapped_smiles, strict=False)
+    connectivity_table = utils.get_connectivity_table(molecule, atom_map)
 
     for bond in connectivity_table:
         xi = np.isin(expected_table, bond[:2])
@@ -301,22 +315,17 @@ def test_map_order_geometry(permute, toolkit, toolkit_name):
     }
     mol = utils.load_molecule(hooh, toolkit=toolkit_name, permute_xyz=permute)
     mapped_smiles = utils.mol_to_smiles(mol, isomeric=True, explicit_hydrogen=True, mapped=True)
-    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles)
+    atom_map = utils.get_atom_map(mol, mapped_smiles=mapped_smiles, strict=permute)
+    symbols, geometry = toolkit.get_map_ordered_geometry(mol, atom_map)
+
+    json_geom = np.asarray(hooh['geometry']).reshape(int(len(geometry)/3), 3)
+    geometry_array = np.asarray(geometry).reshape(int(len(geometry)/3), 3)
+
+    for m in atom_map:
+        for i in range(3):
+            assert json_geom[atom_map[m]][i] == pytest.approx(geometry_array[m-1][i], 0.0000001)
     if not permute:
-        # Atom map should match JSON and no reordering is needed
-        for m in atom_map:
-            assert m == atom_map[m] + 1
-    if permute:
-        symbols, geometry = toolkit.get_map_ordered_geometry(mol, mapped_smiles)
-
-        json_geom = np.asarray(hooh['geometry']).reshape(int(len(geometry)/3), 3)
-        geometry_array = np.asarray(geometry).reshape(int(len(geometry)/3), 3)
-
-        for m in atom_map:
-            for i in range(3):
-                assert json_geom[atom_map[m]][i] == pytest.approx(geometry_array[m-1][i], 0.0000001)
-    # if not permute:
-    #     assert hooh['geometry'] == pytest.approx(geometry, 0.0000001)
+        assert hooh['geometry'] == pytest.approx(geometry, 0.0000001)
 
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
@@ -345,7 +354,7 @@ def test_permute_json(toolkit):
         'connectivity': [[0, 1, 1], [1, 2, 1], [2, 3, 1]],
         'molecular_multiplicity': 1
     }
-    mol = utils.mol_from_json(hooh, toolkit=toolkit, permute_xyz=True)
+    mol = utils.mol_from_json(hooh, toolkit=toolkit)
     atom_map = utils.get_atom_map(mol, mapped_smiles='[H:3][O:1][O:2][H:4]')
     permuted_hooh = utils.permute_qcschema(hooh, molecule_ids, toolkit=toolkit)
 
@@ -369,10 +378,10 @@ def test_get_atom_map_mapped_smiles(toolkit):
     if not utils.has_explicit_hydrogen(mol_2):
         mol_2 = utils.add_explicit_hydrogen(mol_2)
 
-    atom_map = utils.get_atom_map(mol_2, mapped_smiles=smiles_2)
+    atom_map = utils.get_atom_map(mol_2, mapped_smiles=smiles_2, strict=False)
     assert len(atom_map) == 10
-    # with pytest.raises(ValueError):
-    #     utils.get_atom_map(mol_1, mapped_smiles=smiles_1)
+    with pytest.raises(ValueError):
+        utils.get_atom_map(mol_1, mapped_smiles=smiles_1)
 
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
@@ -394,18 +403,17 @@ def test_remove_restore_atom_map(toolkit):
         utils.restore_atom_map(mol)
 
 
-# @pytest.mark.parametrize('toolkit', toolkits_name)
-# @pytest.mark.parametrize('smiles, canonicalization', [('[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]', 'openeye'),
-#                                                       ('[O:1]([C:3]([C:4]([O:2][H:6])([H:9])[H:10])([H:7])[H:8])[H:5]', 'rdkit'),
-#                                                       ('[H:7][C:1]1([C:2]([C:4]([C:5]([C:3]1([H:11])[H:12])([H:15])[C:6]([H:16])([H:17])[H:18])([H:13])[H:14])([H:9])[H:10])[H:8]', 'openeye')])
-# def test_is_map_canonical(toolkit, smiles, canonicalization):
-#     molecule = utils.load_molecule(smiles, toolkit)
-#
-#     canonical = utils.is_map_canonical(molecule)
-#     if toolkit == canonicalization:
-#         assert canonical
-#     else:
-#         assert not canonical
+@pytest.mark.parametrize('toolkit', toolkits_name)
+@pytest.mark.parametrize('smiles, canonicalization', [('[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]', 'openeye'),
+                                                      ('[O:1]([C:3]([C:4]([O:2][H:6])([H:9])[H:10])([H:7])[H:8])[H:5]', 'rdkit')])
+def test_is_map_canonical(toolkit, smiles, canonicalization):
+    molecule = utils.load_molecule(smiles, toolkit)
+
+    canonical = utils.is_map_canonical(molecule)
+    if toolkit == canonicalization:
+        assert canonical
+    else:
+        assert not canonical
 
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
@@ -429,40 +437,3 @@ def test_atom_order_in_mol_copy(toolkit, smiles):
             assert a1.GetIdx() == a2.GetIdx()
             assert a1.GetAtomMapNum() == a2.GetAtomMapNum()
             assert a1.GetSmarts() == a2.GetSmarts()
-
-
-@using_openeye
-@pytest.mark.parametrize('smiles', ['CC1CCCC1', 'OCCO', 'C[C@H](C1CCCC1)n2cc(cn2)c3c4cc[nH]c4ncn3'])
-def test_canonical_geometry_order(smiles):
-    from .utils import generate_conformers
-    mol = utils.load_molecule(smiles, toolkit='openeye')
-    mol = utils.add_explicit_hydrogen(mol)
-
-    # Generate conformer
-    conf_canonical = generate_conformers(mol, canonical_order=True)
-    conf = generate_conformers(mol, canonical_order=False)
-
-    assert _cmiles_oe.is_goemetry_canonical_order(conf_canonical) == True
-    with pytest.warns(UserWarning):
-        assert _cmiles_oe.is_goemetry_canonical_order(conf) == False
-
-
-@using_openeye
-@pytest.mark.parametrize('smiles, output', [('[H:7][C:1]1([C:2]([C:4]([C:5]([C:3]1([H:11])[H:12])([H:15])[C:6]([H:16])([H:17])[H:18])([H:13])[H:14])([H:9])[H:10])[H:8]', True),
-                                    ('[H:9][C:2]1([C:1]([C:3]([C:5]([C:4]1([H:13])[H:14])([H:15])[C:6]([H:16])([H:17])[H:18])([H:11])[H:12])([H:7])[H:8])[H:10]', False),
-                                    ('[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]', True),
-                                    ('[H:7][C:2]([H:8])([C:1]([H:5])([H:6])[O:3][H:9])[O:4][H:10]', False)])
-def test_canonical_mapped_smiles(smiles, output):
-    assert _cmiles_oe.is_mapped_smiles_canonical(smiles) == output
-
-@using_openeye
-@pytest.mark.parametrize('smiles', ['[H:7][C:1]1([C:2]([C:4]([C:5]([C:3]1([H:11])[H:12])([H:15])[C:6]([H:16])([H:17])[H:18])([H:13])[H:14])([H:9])[H:10])[H:8]',
-                                    '[H:9][C:2]1([C:1]([C:3]([C:5]([C:4]1([H:13])[H:14])([H:15])[C:6]([H:16])([H:17])[H:18])([H:11])[H:12])([H:7])[H:8])[H:10]',
-                                    '[H:5][C:1]([H:6])([C:2]([H:7])([H:8])[O:4][H:10])[O:3][H:9]',
-                                    '[H:7][C:2]([H:8])([C:1]([H:5])([H:6])[O:3][H:9])[O:4][H:10]'])
-def test_canonical_atom_order(smiles):
-    mol = oechem.OEMol()
-    oechem.OESmilesToMol(mol, smiles)
-    assert _cmiles_oe.is_molecule_canonical_order(mol) == False
-    _cmiles_oe.canonical_order_atoms(mol)
-    assert _cmiles_oe.is_molecule_canonical_order(mol) == True

--- a/cmiles/tests/test_utils.py
+++ b/cmiles/tests/test_utils.py
@@ -34,14 +34,26 @@ def test_load_molecule(toolkit):
 
 
 @pytest.mark.parametrize('toolkit', toolkits_name)
-def test_is_mapped(toolkit):
+@pytest.mark.parametrize('input, output', [('[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]', True),
+                                           ('[H:3][C:1]([H])([H:5])[C]([H])([H:7])[H:8]', True),
+                                           ('CCCC', False)])
+
+def test_is_mapped(toolkit, input, output):
     """Test is mapped"""
-    mapped_smiles = '[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]'
-    mapped_mol = utils.load_molecule(mapped_smiles, toolkit=toolkit)
-    assert utils.has_atom_map(mapped_mol) == True
+    mapped_mol = utils.load_molecule(input, toolkit=toolkit)
+    assert utils.has_atom_map(mapped_mol) == output
     utils.remove_atom_map(mapped_mol)
     assert utils.has_atom_map(mapped_mol) == False
 
+
+@pytest.mark.parametrize('toolkit', toolkits_name)
+@pytest.mark.parametrize('input, output', [('[H:3][C:1]([H:4])([H:5])[C:2]([H:6])([H:7])[H:8]', False),
+                                           ('[H:3][C:1]([H:4])([H:5])[C]([H:6])([H:7])[H:8]', True),
+                                           ('CCCC', True)])
+def test_is_missing_map(toolkit, input, output):
+    #ToDo - Known problem that RDKit does not add explicit H to molecules even with explicit H SMILES so if map of H is missing it will not pick it up
+    mol = utils.load_molecule(input, toolkit=toolkit)
+    assert utils.is_missing_atom_map(mol) == output
 
 @pytest.mark.parametrize('toolkit_str', toolkits_name)
 def test_mol_from_json(toolkit_str):

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -4,6 +4,7 @@ Utility functions for cmiles generator
 import numpy as np
 import copy
 import collections
+import warnings
 
 try:
     from rdkit import Chem
@@ -379,6 +380,8 @@ def restore_atom_map(molecule):
     """
     toolkit = _set_toolkit(molecule)
     toolkit.restore_atom_map(molecule)
+    if not has_atom_map(molecule):
+        warnings.warn("There were no atom maps in atom data to restore")
 
 
 def has_stereo_defined(molecule):

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -216,10 +216,11 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1, **kwargs
     """
     toolkit = _set_toolkit(molecule)
     mapped_smiles = molecule_ids['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
+    #atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
 
-    connectivity = get_connectivity_table(molecule, atom_map)
-    symbols, geometry = toolkit.get_map_ordered_geometry(molecule, atom_map)
+    symbols, geometry = toolkit.get_map_ordered_geometry(molecule, mapped_smiles)
+    connectivity = get_connectivity_table(molecule)
+
     charge = get_charge(molecule)
 
     qcschema_mol = {'symbols': symbols, 'geometry': geometry, 'connectivity': connectivity,
@@ -250,7 +251,7 @@ def get_atom_map(molecule, mapped_smiles, **kwargs):
     return atom_map
 
 
-def get_connectivity_table(molecule, atom_map):
+def get_connectivity_table(molecule):
     """
     Generate connectivity table
 
@@ -270,8 +271,8 @@ def get_connectivity_table(molecule, atom_map):
     """
 
     toolkit = _set_toolkit(molecule)
-    inverse_map = dict(zip(atom_map.values(), atom_map.keys()))
-    return toolkit.get_connectivity_table(molecule, inverse_map)
+    #inverse_map = dict(zip(atom_map.values(), atom_map.keys()))
+    return toolkit.get_connectivity_table(molecule)
 
 
 def permute_qcschema(json_mol, molecule_ids, **kwargs):
@@ -294,7 +295,7 @@ def permute_qcschema(json_mol, molecule_ids, **kwargs):
         Also includes `identifiers` field with cmiles generated identifiers.
 
     """
-    molecule = mol_from_json(json_mol, **kwargs)
+    molecule = mol_from_json(json_mol, permute_xyz=True)
     ordered_qcschema = mol_to_map_ordered_qcschema(molecule, molecule_ids, json_mol['molecular_multiplicity'])
 
     return ordered_qcschema

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -228,7 +228,8 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1, **kwargs
     return qcschema_mol
 
 
-def get_atom_map(molecule, mapped_smiles, **kwargs):
+
+def get_atom_map(molecule, mapped_smiles):
     """
     Get mapping of map index -> atom index
 
@@ -246,7 +247,8 @@ def get_atom_map(molecule, mapped_smiles, **kwargs):
 
     """
     toolkit = _set_toolkit(molecule)
-    atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
+
+    atom_map = toolkit.get_atom_map(molecule, mapped_smiles)
     return atom_map
 
 

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -216,11 +216,10 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1, **kwargs
     """
     toolkit = _set_toolkit(molecule)
     mapped_smiles = molecule_ids['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    #atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
+    atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
 
-    symbols, geometry = toolkit.get_map_ordered_geometry(molecule, mapped_smiles)
-    connectivity = get_connectivity_table(molecule)
-
+    connectivity = get_connectivity_table(molecule, atom_map)
+    symbols, geometry = toolkit.get_map_ordered_geometry(molecule, atom_map)
     charge = get_charge(molecule)
 
     qcschema_mol = {'symbols': symbols, 'geometry': geometry, 'connectivity': connectivity,
@@ -251,7 +250,7 @@ def get_atom_map(molecule, mapped_smiles, **kwargs):
     return atom_map
 
 
-def get_connectivity_table(molecule):
+def get_connectivity_table(molecule, atom_map):
     """
     Generate connectivity table
 
@@ -271,8 +270,8 @@ def get_connectivity_table(molecule):
     """
 
     toolkit = _set_toolkit(molecule)
-    #inverse_map = dict(zip(atom_map.values(), atom_map.keys()))
-    return toolkit.get_connectivity_table(molecule)
+    inverse_map = dict(zip(atom_map.values(), atom_map.keys()))
+    return toolkit.get_connectivity_table(molecule, inverse_map)
 
 
 def permute_qcschema(json_mol, molecule_ids, **kwargs):
@@ -295,7 +294,7 @@ def permute_qcschema(json_mol, molecule_ids, **kwargs):
         Also includes `identifiers` field with cmiles generated identifiers.
 
     """
-    molecule = mol_from_json(json_mol, permute_xyz=True)
+    molecule = mol_from_json(json_mol, **kwargs)
     ordered_qcschema = mol_to_map_ordered_qcschema(molecule, molecule_ids, json_mol['molecular_multiplicity'])
 
     return ordered_qcschema

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -228,8 +228,7 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1, **kwargs
     return qcschema_mol
 
 
-
-def get_atom_map(molecule, mapped_smiles):
+def get_atom_map(molecule, mapped_smiles, **kwargs):
     """
     Get mapping of map index -> atom index
 
@@ -485,3 +484,20 @@ def _set_toolkit(molecule):
     else:
         raise RuntimeError("Must have openeye or rdkit installed")
     return toolkit
+
+
+def invert_atom_map(atom_map):
+    """
+    Invert atom map {map_idx:atom_idx} --> {atom_idx:map_idx}
+    Parameters
+    ----------
+    atom_map: dict
+        {map_idx:atom_idx}
+
+    Returns
+    -------
+    inverse_map: dict
+        {atom_idx:map_idx}
+
+    """
+    return dict(zip(atom_map.values(), atom_map.keys()))

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -353,13 +353,15 @@ def is_map_canonical(molecule):
     return toolkit.is_map_canonical(molecule)
 
 
-def remove_atom_map(molecule):
+def remove_atom_map(molecule, keep_map_data=True):
     """
     Remove atom map from molecule in place
     Parameters
     ----------
     molecule
         oechem.OEMol or rdkit.Chem.Mol
+    keep_map_data: bool, optional, default True
+        If True, will save map indices in atom data
 
     """
     toolkit = _set_toolkit(molecule)

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -227,7 +227,7 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1):
     return qcschema_mol
 
 
-def get_atom_map(molecule, mapped_smiles):
+def get_atom_map(molecule, **kwargs):
     """
     Get mapping of map index -> atom index
 
@@ -245,7 +245,7 @@ def get_atom_map(molecule, mapped_smiles):
 
     """
     toolkit = _set_toolkit(molecule)
-    atom_map = toolkit.get_atom_map(molecule, mapped_smiles)
+    atom_map = toolkit.get_atom_map(molecule, **kwargs)
     return atom_map
 
 
@@ -346,6 +346,19 @@ def remove_atom_map(molecule):
     """
     toolkit = _set_toolkit(molecule)
     toolkit.remove_atom_map(molecule)
+
+
+def restore_atom_map(molecule):
+    """
+    Restore atom map from atom data
+    Parameters
+    ----------
+    molecule
+        oechem.OEMol or rdkit.Chem.Mol
+
+    """
+    toolkit = _set_toolkit(molecule)
+    toolkit.restore_atom_map(molecule)
 
 
 def has_stereo_defined(molecule):

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -147,6 +147,8 @@ def mol_to_smiles(molecule, **kwargs):
     """
     molecule = copy.deepcopy(molecule)
     toolkit = _set_toolkit(molecule)
+    if has_atom_map(molecule):
+        remove_atom_map(molecule)
     return toolkit.mol_to_smiles(molecule, **kwargs)
 
 
@@ -299,7 +301,7 @@ def permute_qcschema(json_mol, molecule_ids, **kwargs):
 
 def has_atom_map(molecule):
     """
-    Check if molecule has atom map indices
+    Check if molecule has atom map indices. Will return True even if only one atom has map index
 
     Parameters
     ----------
@@ -313,6 +315,24 @@ def has_atom_map(molecule):
     """
     toolkit = _set_toolkit(molecule)
     return toolkit.has_atom_map(molecule)
+
+
+def is_missing_atom_map(molecule):
+    """
+    Check if any atom in molecule is missing atom map index
+
+    Parameters
+    ----------
+    molecule:
+        oechem.Mol or rdkit.Chem.Mol
+
+    Returns
+    -------
+    True or False
+
+    """
+    toolkit = _set_toolkit(molecule)
+    return toolkit.is_missing_atom_map(molecule)
 
 
 def remove_atom_map(molecule):

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -191,7 +191,7 @@ def mol_to_hill_molecular_formula(molecule):
     return "".join(hill_sorted)
 
 
-def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1):
+def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1, **kwargs):
     """
     Genereate JSON serialize following qc-schema specs (https://molssi-qc-schema.readthedocs.io/en/latest/index.html#)
     Geometry, symbols and connectivity table ordered according to map indices in mapped
@@ -215,7 +215,7 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1):
     """
     toolkit = _set_toolkit(molecule)
     mapped_smiles = molecule_ids['canonical_isomeric_explicit_hydrogen_mapped_smiles']
-    atom_map = toolkit.get_atom_map(molecule, mapped_smiles)
+    atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
 
     connectivity = get_connectivity_table(molecule, atom_map)
     symbols, geometry = toolkit.get_map_ordered_geometry(molecule, atom_map)
@@ -227,7 +227,7 @@ def mol_to_map_ordered_qcschema(molecule, molecule_ids, multiplicity=1):
     return qcschema_mol
 
 
-def get_atom_map(molecule, **kwargs):
+def get_atom_map(molecule, mapped_smiles, **kwargs):
     """
     Get mapping of map index -> atom index
 
@@ -245,7 +245,7 @@ def get_atom_map(molecule, **kwargs):
 
     """
     toolkit = _set_toolkit(molecule)
-    atom_map = toolkit.get_atom_map(molecule, **kwargs)
+    atom_map = toolkit.get_atom_map(molecule, mapped_smiles, **kwargs)
     return atom_map
 
 
@@ -335,6 +335,24 @@ def is_missing_atom_map(molecule):
     return toolkit.is_missing_atom_map(molecule)
 
 
+def is_map_canonical(molecule):
+    """
+    Check if any atom in molecule is missing atom map index
+
+    Parameters
+    ----------
+    molecule:
+        oechem.Mol or rdkit.Chem.Mol
+
+    Returns
+    -------
+    True or False
+
+    """
+    toolkit = _set_toolkit(molecule)
+    return toolkit.is_map_canonical(molecule)
+
+
 def remove_atom_map(molecule):
     """
     Remove atom map from molecule in place
@@ -399,6 +417,21 @@ def has_explicit_hydrogen(molecule):
     """
     toolkit = _set_toolkit(molecule)
     return toolkit.has_explicit_hydrogen(molecule)
+
+
+def add_explicit_hydrogen(molecule):
+    """
+    Add explicit hydrogen to molecule
+    Parameters
+    ----------
+    molecule
+
+    Returns
+    -------
+
+    """
+    toolkit = _set_toolkit(molecule)
+    return toolkit.add_explicit_hydrogen(molecule)
 
 
 def get_charge(molecule):


### PR DESCRIPTION
## Description
The PR addresses several issues with atom map indices. 


1. Get an atom map for a molecule to the map indices on the mapped SMILES `{MapIdx:Idx}`
There are 2 ways to get an atom map {MapIdx:atomIdx}: 

   - A.  Substructure search
            **Problem**: For symmetrical molecules, the map indices can flip. 
       * Substructure searches should only be used as a way to recover order of molecules that for some reason cannot be reordered to canonical order.  
    - B. From map indices on molecule
           **Problem**: How do we guarantee that the map indices are the canonical map indices? 
**Solution**: Have one function to canonicalize atom indices. Then check that map indices are +1 of atom indices. If not - the map indices are arbitrary and should not be used to generate qcschema geometry
_This will only work if the initial mapped SMILES was generated with the same toolkit as the canonical order since the canonicalization order algorithms are different._ 
_This cannot work for rdkit because there is no way to reorder the atoms. RDKit's canonical order ranking of atoms are the canonical map indices._

2. Conformations generated from molecules that have map indices are different than ones generated without map indices.
From openeye support: 
> The coordinates are generally reproducible (i.e the same) because OMEGA usually starts from pre-built fragments from the frag lib. This is done via a text match using the isomeric SMILES. However, molecules with map indices will fail the isomeric SMILES lookup because of the indices themselves in the SMILES string. So therefore, the fragments are regenerated instead via an optimized DG (distance geometry) algorithm, which can lead to differences in the 3D coordinates. To remedy this, you would need to blow away the map indices and then run OMEGA. You can do this by iterating through the atoms and setting the map index for each atom to 0. If you need to keep the map index information, you can simply set this as generic data on each atom before blowing away the map index. Then, you can run omega and post process the results by going back in and resetting the map indices from the generic data. 

3. `has_atom_map` returned `False` even if only one atom did not have a map index. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] `has_atom_map` returns `True` if one atom has a map index. 
  - [x] Added `is_missing_atom_map` to return `True` if any atom is missing a map index. 
  - [ ] Change `get_atom_map` to create atom map from map indices on molecule (check order first)

## Status
- [ ] Ready to go