### PR TITLE
Small fix

### DIFF
--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -247,8 +247,9 @@ def get_map_ordered_geometry(molecule, atom_map):
     if not molecule.GetDimension() == 3:
         raise RuntimeError("Molecule must have 3D coordinates for generating a QCSchema molecule")
 
-    if molecule.GetMaxConfIdx() != 1:
-        raise Warning("The molecule must have at least and at most 1 conformation")
+    if isinstance(molecule, oechem.OEMol):
+        if molecule.GetMaxConfIdx() != 1:
+            raise Warning("The molecule must have at least and at most 1 conformation")
 
     symbols = []
     geometry = []

--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -236,12 +236,16 @@ def get_map_ordered_geometry(molecule, atom_map):
 
     Parameters
     ----------
-    molecule
-    atom_map
+    molecule: OEMol with 1 conformer or OEConf
+    atom_map: dict
+        map_idx:atom_idx
 
     Returns
     -------
-
+    symbols: list of str
+        list of symbols
+    geometry: list of ints
+        xyz geometry. List is length N*3
     """
 
     if not molecule.GetDimension() == 3:


### PR DESCRIPTION
## Description
`get_map_ordered_geometry` can take as input an OEMol or OEConf. A conformer does not need to be checked if it only has one conformer, only an OEMol needs to be checked. 
