### PR TITLE
Drop cron job while tests are failing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,11 +9,9 @@ on:
     branches:
       - "master"
       - "maintenance/.+"
-  schedule:
-    # Nightly tests run on master by default:
-    #   Scheduled workflows run on the latest commit on the default or base branch.
-    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
-    - cron: "0 0 * * *"
+# Add cron job back after #39 is fixed
+# schedule:
+#   - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
### Description
This PR comments out the cron job in the CI script. The email associated with the last commit (me) gets nightly emails about the failing status.  This is pretty annoying and will likely continue for a while until the actual failing tests are fixed (unclear timeline, since it's only a few edge cases with recent RDKit changes, not core functionality, that has changed). This is well-documented (#39 and a few places in our other tools) so we are not likely to forget about it.