### PR TITLE
Revert "Drop cron job while tests are failing"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,11 @@ on:
     branches:
       - "master"
       - "maintenance/.+"
-# Add cron job back after #39 is fixed
-# schedule:
-#   - cron: "0 0 * * *"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
Using the GitHub UI to do this

Reverts openforcefield/cmiles#42, which is no longer needed after #44, and will allow us to catch actual failures when something upstream changes again