### PR TITLE
Fix shape comparisons in geometry array

### DIFF
--- a/cmiles/_cmiles_oe.py
+++ b/cmiles/_cmiles_oe.py
@@ -39,10 +39,10 @@ def mol_from_json(symbols, connectivity, geometry, permute_xyz=False):
         molecule.NewBond(a1, a2, int(bond_order))
 
     # Add geometry
-    if molecule.NumAtoms() != geometry.shape[0]/3:
+    if molecule.NumAtoms() != geometry.shape[0]:
         raise ValueError("Number of atoms in molecule does not match length of position array")
 
-    molecule.SetCoords(oechem.OEFloatArray(geometry))
+    molecule.SetCoords(oechem.OEFloatArray(geometry.flatten()))
     molecule.SetDimension(3)
 
     if not permute_xyz:

--- a/cmiles/_cmiles_rd.py
+++ b/cmiles/_cmiles_rd.py
@@ -26,7 +26,7 @@ def mol_from_json(symbols, connectivity, geometry, permute_xyz=False):
 
     _BO_DISPATCH_TABLE = {1: Chem.BondType.SINGLE, 2: Chem.BondType.DOUBLE, 3: Chem.BondType.TRIPLE}
 
-    geometry = geometry.reshape(int(len(geometry)/3), 3)
+    geometry = geometry.reshape((-1, 3))
     conformer = Chem.Conformer(len(symbols))
     has_geometry = True
 

--- a/cmiles/utils.py
+++ b/cmiles/utils.py
@@ -124,7 +124,7 @@ def mol_from_json(inp_molecule, toolkit='openeye', **kwargs):
 
     # convert to Angstrom.
     geometry = np.asarray(inp_molecule['geometry'], dtype=float)*BOHR_2_ANGSTROM
-    if len(symbols) != geometry.shape[0]/3:
+    if len(symbols) != geometry.shape[0]:
         raise ValueError("Number of atoms in molecule does not match length of position array")
 
     if toolkit == 'openeye' and has_openeye:


### PR DESCRIPTION
## Description
This may fix #55 - all I did was get the snippet to work. I have not investigated if the result oemols/rdmols are valid. I could not find existing tests that compare directly against QCMols, so I used a modified version of the reproducing snippet to spot-check this:


```python3
import qcportal as ptl
import cmiles

print(ptl.__version__)
print(cmiles.__version__)

qc_client  = ptl.FractalClient("https://api.qcarchive.molssi.org:443/")
ds         = qc_client.get_collection('TorsionDriveDataset', "OpenFF Substituted Phenyl Set 1")
qcrecord   = ds.get_record("CCC(=O)Nc1[cH:1][c:2](ccn1)[NH:3][CH2:4]C",
                           specification="default")
qcmols     = qcrecord.get_final_molecules()

for torsion_crd, qcmol in qcmols.items():
    print(qcmol.symbols.shape)
    print(qcmol.geometry.shape)
    print(qcmol.symbols.shape[0]==qcmol.geometry.shape[0])
    oemol = cmiles.utils.load_molecule(qcmol.dict(), toolkit="openeye")
    rdmol = cmiles.utils.load_molecule(qcmol.dict(), toolkit="rdkit")
```

I skimmed the QCElemental/QCSChema chagelogs/histories but could not quickly discern where these changes might have taken place.